### PR TITLE
Removal of deprecated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,7 @@ You can follow the instructions in this document to [add content blocks to the p
 
 ## Configuration
 
-- Ensure that your root directory does not contain any `.git` hidden folders or files
-- Follow the base theme folder directory even when the folder are empty
-- Make sure the root folder is named `theme`
-- Compress it to a zip file
-- Name your zip file `theme`
 - Upload it via the theme importer
-- Now, go to the theme template list and remove the `.liquid` on each template
-- Rename
-  - snippets/products/card/simple_card > snippets/products/simple_card
-  - snippets/products/card/card > snippets/products/card
 - Preview your theme
 
 ### Recommended Help Articles


### PR DESCRIPTION
## Notes

We no longer needs the instructions that makes users to rename templates and upload the zip file with a specific format. The current theme importer allows users to seamless upload their theme and preview it straightaway.