### PR TITLE
Theme Identification for v20

### DIFF
--- a/templates/layouts/theme.liquid
+++ b/templates/layouts/theme.liquid
@@ -21,6 +21,8 @@
     {{ csp_meta_tag }}
     {%- render "meta_data", title: title, meta_keywords: meta_keywords, meta_description: meta_description %}
 
+    {%- render "shared/theme_identity" %}
+
     {%- comment -%} Styles {%- endcomment -%}
     {% require "styles/theme.css" %}
     {{ theme_supplement_stylesheet }}

--- a/templates/snippets/shared/theme_identity.liquid
+++ b/templates/snippets/shared/theme_identity.liquid
@@ -1,7 +1,7 @@
 {%- comment -%}
-StoreConnect Theme: Clean Theme - v20
+  StoreConnect Theme: Clean Theme - v20
 {%- endcomment -%}
 
-<meta name="SC-Theme" content="Clean Theme - v20">
-<meta name="SC-Theme_name" content="Clean Theme">
-<meta name="SC-Theme_version" content="20">
+<meta name="sc-theme" content="Clean Theme - v20">
+<meta name="sc-theme-name" content="Clean Theme">
+<meta name="sc-theme-version" content="20">

--- a/templates/snippets/shared/theme_identity.liquid
+++ b/templates/snippets/shared/theme_identity.liquid
@@ -1,0 +1,7 @@
+{%- comment -%}
+StoreConnect Theme: Clean Theme - v20
+{%- endcomment -%}
+
+<meta name="SC-Theme" content="Clean Theme - v20">
+<meta name="SC-Theme_name" content="Clean Theme">
+<meta name="SC-Theme_version" content="20">


### PR DESCRIPTION
This PR introduces a standardized way to embed original theme identification into the <head> of every StoreConnect theme. This ensures that anyone reviewing a theme, developers, partners, or support staff can quickly determine which theme the store was originally downloaded as and which version it was based on.

What’s Included

- Added a new shared snippet: `snippets/shared/theme_identity.liquid`

- Inserted the snippet into the <head> section of the theme layout so it will appear on every page.

- Ensured the snippet is hard-wired per theme, allowing each theme to store its own identity without relying on runtime data.